### PR TITLE
Update repo/GitHub pages links to correct renamed locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/IgniteUI/igniteui-react-wrappers/badge.svg?branch=master)](https://coveralls.io/github/IgniteUI/igniteui-react-wrappers?branch=master)
 [![npm version](https://badge.fury.io/js/igniteui-react.svg)](https://badge.fury.io/js/igniteui-react)
 
-Use the declarations available in `igniteui-react.js` (or `igniteui-react.min.js`) to use [Ignite UI](http://igniteui.com) controls as [React](https://facebook.github.io/react/) components. [Work with the running samples here](https://igniteui.github.io/igniteui-react/).
+Use the declarations available in `igniteui-react.js` (or `igniteui-react.min.js`) to use [Ignite UI](http://igniteui.com) controls as [React](https://facebook.github.io/react/) components. [Work with the running samples here](https://igniteui.github.io/igniteui-react-wrappers/).
 
 **IMPORTANT** The repository has been renamed from `igniteui-react` to `igniteui-react-wrappers`. For now the package name will stay with the `igniteui-react` name.
 There is a new product [Ignite UI for React](https://www.infragistics.com/products/ignite-ui-react) from Infragistics that you may want to consider when starting your next React project. It features a high-performance data grid, high-volume data charts and a complete Microsoft Excel Solution. Please check out the announcement [here](https://www.infragistics.com/community/blogs/b/infragistics/posts/announcing-ignite-ui-for-react-components).
@@ -205,7 +205,7 @@ Go to the folder of the sample you want to run:
 	npm install
 	npm start
 
-Alternatively you can view them from [here](https://igniteui.github.io/igniteui-react/).
+Alternatively you can view them from [here](https://igniteui.github.io/igniteui-react-wrappers/).
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/IgniteUI/igniteui-react.git"
+    "url": "https://github.com/IgniteUI/igniteui-react-wrappers.git"
   },
   "dependencies": {
     "react": "^16.6.3",


### PR DESCRIPTION
Would be nice if there's a tag after this PR so the [npm package page](https://www.npmjs.com/package/igniteui-react) can pickup new content and the correct repo link